### PR TITLE
Correct calculation of normalisation factor K

### DIFF
--- a/src/sh.rs
+++ b/src/sh.rs
@@ -146,10 +146,10 @@ fn factorial(n: u64) -> u64 {
 #[inline]
 fn K<T: SphrsFloat>(l: i64, m: i64) -> T {
     ((T::from_f64(2.0).unwrap() * T::from_i64(l).unwrap() + T::one())
-        * T::from_u64(factorial((l - m).abs() as u64)).unwrap()
+        * T::from_u64(factorial((l - m.abs()) as u64)).unwrap()
         / (T::from_f64(4.0).unwrap()
             * T::PI()
-            * T::from_u64(factorial((l + m).abs() as u64)).unwrap()))
+            * T::from_u64(factorial((l + m.abs()) as u64)).unwrap()))
     .sqrt()
 
     // let m = m.abs();


### PR DESCRIPTION
Page 12 of Green's *Spherical Harmonic Lighting: The Gritty Details* has given the normalisation factor K(m,l) as follows
![image](https://user-images.githubusercontent.com/7034308/100019946-dbdee000-2dd6-11eb-8236-6214cf05e716.png)
here, the absolute value of m is taken. This is also the case in Google's implementation:

https://github.com/google/spherical-harmonics/blob/5191bdf6085b6864395d3c0f4ba2e191115bb133/sh/spherical_harmonics.cc#L507-L508

But in `sh.rs`, the absolute value of (l-m) was taken. This would be incorrect for negative values of m.