### PR TITLE
Tests in coords module, removed some generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ num-complex = "0.4"
 num-traits = "0.2"
 
 [dev-dependencies]
+approx = { version = "0.5.1", features = ["num-complex"] }
 csv = "1"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use std::f64::consts::PI;
 let sh = ComplexSHType::Spherical;
 let degree = 2;
 let order = 1;
-let p: Coordinates<f64> = Coordinates::spherical(1.0, PI/4.0, PI/8.0);
+let p = Coordinates::spherical(1.0, PI/4.0, PI/8.0);
 println!("SH ({}, {}): {:?}", degree, order, sh.eval(degree, order, &p));
 ```
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -24,7 +24,7 @@ mod tests {
         let sh = RealSHType::Spherical;
         let l = 4;
         let m = -1;
-        let p: Coordinates<f64> = Coordinates::spherical(1.0, PI / 2.0, 0.0);
+        let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
         b.iter(|| {
             black_box(sh.eval(l, m, &p));
         });

--- a/deny.toml
+++ b/deny.toml
@@ -80,7 +80,7 @@ allow = [
     # "Apache-2.0 WITH LLVM-exception",
     # "BSD-2-Clause",
     # "BSD-3-Clause",
-    # "Unicode-DFS-2016",
+    "Unicode-DFS-2016",
     # "MPL-2.0",
     # "ISC",
     # "OpenSSL",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! let sh = ComplexSHType::Spherical;
 //! let degree = 2;
 //! let order = 1;
-//! let p: Coordinates<f64> = Coordinates::spherical(1.0, PI/4.0, PI/8.0);
+//! let p = Coordinates::spherical(1.0, PI/4.0, PI/8.0);
 //! println!("SH ({}, {}): {:?}", degree, order, sh.eval(degree, order, &p));
 //! ```
 //!


### PR DESCRIPTION
Added tests in coords module.

Also removed generics of the `cartesian` and `spherical` methods of `Coordinates`. This was well intended to be able to use a wider range of possible input types and automatically convert them to the desired output type. However this added the necessity to specify what the desired output type is, which isn't really convenient given that most people probably just want to have the same output type as the input type. 

Essentially, this isn't necessary anymore:

```rust
let coords: Coordinates<f64> = Coordinates::spherical(radius, theta, phi);
```

instead, one can do this:

```rust
let coords = Coordinates::spherical(radius, theta, phi);
```

Then `coords` will have the type `Coordinates<T>` where `T` is equal to the type of `radius`, `theta` and `phi`. 