### PR TITLE
Made coords and sh module non pub, only reexports in root available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,9 @@
 #![warn(missing_docs)]
 
 /// Coordinates
-pub mod coords;
+mod coords;
 /// Spherical/solid harmonics
-pub mod sh;
+mod sh;
 
 pub use crate::coords::*;
 pub use crate::sh::*;


### PR DESCRIPTION
If you accessed anything via `sphrs::coords::*` or `sphrs::sh::*` please change that to `sphrs::*`. The modules are now non-public, only the re-exports in the root are available. 