### PR TITLE
Remove `Type` suffix from `ComplexSHType` and `RealSHType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Documentation: [stable](https://docs.rs/sphrs/latest/sphrs),
 
 ## Types of spherical/solid harmonics
 
-This crate supports these types of real and complex functions via the enums `RealSHType` and
-`ComplexSHType`:
+This crate supports these types of real and complex functions via the enums `RealSH` and `ComplexSH`:
 
 * [Spherical](https://en.wikipedia.org/wiki/Spherical_harmonics)
 * [RegularSolid and IrregularSolid](https://en.wikipedia.org/wiki/Solid_harmonics)
@@ -31,10 +30,10 @@ Compute the complex spherical harmonic function of degree 2 and order 1 at (sphe
 (r = 1.0, theta = PI/4, phi = PI/4):
 
 ```rust
-use sphrs::{ComplexSHType, Coordinates, SHEval};
+use sphrs::{ComplexSH, Coordinates, SHEval};
 use std::f64::consts::PI;
 
-let sh = ComplexSHType::Spherical;
+let sh = ComplexSH::Spherical;
 let degree = 2;
 let order = 1;
 let p = Coordinates::spherical(1.0, PI/4.0, PI/8.0);
@@ -44,9 +43,9 @@ println!("SH ({}, {}): {:?}", degree, order, sh.eval(degree, order, &p));
 Compute all real SH up to 5th degree at (Cartesian) position (1, 0, 0):
 
 ```rust
-use sphrs::{RealSHType, HarmonicsSet, Coordinates};
+use sphrs::{RealSH, HarmonicsSet, Coordinates};
 let degree = 5;
-let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, RealSHType::Spherical);
+let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, RealSH::Spherical);
 let p = Coordinates::cartesian(1.0, 0.0, 0.0);
 println!("SH up to degree {}: {:?}", degree, sh.eval(&p));
 ```

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[bench]
     fn eval_single(b: &mut Bencher) {
-        let sh = RealSHType::Spherical;
+        let sh = RealSH::Spherical;
         let l = 4;
         let m = -1;
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -32,7 +32,7 @@ mod tests {
 
     #[bench]
     fn eval(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 5;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -43,7 +43,7 @@ mod tests {
 
     #[bench]
     fn eval_f32(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 5;
         let sh: HarmonicsSet<f32, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0f32, PI32 / 2.0f32, 0.0f32);
@@ -54,7 +54,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_01(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 1;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -65,7 +65,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_02(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 2;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -76,7 +76,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_03(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 3;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -87,7 +87,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_04(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 4;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -98,7 +98,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_05(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 5;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -109,7 +109,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_06(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 6;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -120,7 +120,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_07(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 7;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -131,7 +131,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_08(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 8;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -142,7 +142,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_09(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 9;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -153,7 +153,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_10(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 10;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -164,7 +164,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_11(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 11;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -175,7 +175,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_12(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 12;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -186,7 +186,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_13(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 13;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -197,7 +197,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_14(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 14;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -208,7 +208,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_15(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 15;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -219,7 +219,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_16(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 16;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -230,7 +230,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_17(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 17;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -241,7 +241,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_18(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 18;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -252,7 +252,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_19(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 19;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);
@@ -263,7 +263,7 @@ mod tests {
 
     #[bench]
     fn eval_real_degree_20(b: &mut Bencher) {
-        let sh_type = RealSHType::Spherical;
+        let sh_type = RealSH::Spherical;
         let degree = 20;
         let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, sh_type);
         let p = Coordinates::spherical(1.0, PI / 2.0, 0.0);

--- a/examples/fit.rs
+++ b/examples/fit.rs
@@ -35,7 +35,7 @@
 //     //     }
 //     // }
 //
-//     let sh_type = RealSHType::RegularSolid;
+//     let sh_type = RealSH::RegularSolid;
 //
 //     let target = RealSphericalHarmonics::new(1, sh_type);
 //     // target.set_coeffs(vec![0.1, 2.0, 8.9, 3.2]);
@@ -67,7 +67,7 @@ fn main() {
 // >(
 //     order: usize,
 //     pos: &[impl SHCoordinates<T>],
-//     sh_type: RealSHType,
+//     sh_type: RealSH,
 // ) -> Array2<T> {
 //     let sh = RealSphericalHarmonics::new(order, sh_type);
 //     let mut mat = unsafe { Array2::uninitialized((pos.len(), sh.num_sh)) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //!
 //! # Types of spherical/solid harmonics
 //!
-//! This crate supports these types of real and complex functions via the enums `RealSHType` and
-//! `ComplexSHType`:
+//! This crate supports these types of real and complex functions via the enums `RealSH` and
+//! `ComplexSH`:
 //!
 //! * [Spherical](https://en.wikipedia.org/wiki/Spherical_harmonics)
 //! * [RegularSolid and IrregularSolid](https://en.wikipedia.org/wiki/Solid_harmonics)
@@ -33,10 +33,10 @@
 //! (r = 1.0, theta = PI/4, phi = PI/4):
 //!
 //! ```rust
-//! use sphrs::{ComplexSHType, Coordinates, SHEval};
+//! use sphrs::{ComplexSH, Coordinates, SHEval};
 //! use std::f64::consts::PI;
 //!
-//! let sh = ComplexSHType::Spherical;
+//! let sh = ComplexSH::Spherical;
 //! let degree = 2;
 //! let order = 1;
 //! let p = Coordinates::spherical(1.0, PI/4.0, PI/8.0);
@@ -46,9 +46,9 @@
 //! Compute all real SH up to 5th degree at (Cartesian) position (1, 0, 0):
 //!
 //! ```rust
-//! use sphrs::{RealSHType, HarmonicsSet, Coordinates};
+//! use sphrs::{RealSH, HarmonicsSet, Coordinates};
 //! let degree = 5;
-//! let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, RealSHType::Spherical);
+//! let sh: HarmonicsSet<f64, _, _> = HarmonicsSet::new(degree, RealSH::Spherical);
 //! let p = Coordinates::cartesian(1.0, 0.0, 0.0);
 //! println!("SH up to degree {}: {:?}", degree, sh.eval(&p));
 //! ```
@@ -102,7 +102,7 @@ impl<I> SphrsFloat for I where I: Float + FloatConst + FromPrimitive + Debug {}
 
 /// Available types of real spherical harmonics and solid harmonics
 #[derive(Clone, Copy)]
-pub enum RealSHType {
+pub enum RealSH {
     /// Spherical harmonics
     Spherical,
     /// Regular solid harmonics
@@ -113,7 +113,7 @@ pub enum RealSHType {
 
 /// Available types of complex spherical harmonics and solid harmonics
 #[derive(Clone, Copy)]
-pub enum ComplexSHType {
+pub enum ComplexSH {
     /// Spherical harmonics
     Spherical,
     /// Regular solid harmonics
@@ -128,7 +128,7 @@ pub trait SHEval<T: SphrsFloat, U> {
     fn eval(&self, l: i64, m: i64, p: &impl SHCoordinates<T>) -> U;
 }
 
-impl<T> SHEval<T, T> for RealSHType
+impl<T> SHEval<T, T> for RealSH
 where
     T: SphrsFloat,
 {
@@ -144,7 +144,7 @@ where
     }
 }
 
-impl<T> SHEval<T, Complex<T>> for ComplexSHType
+impl<T> SHEval<T, Complex<T>> for ComplexSH
 where
     T: SphrsFloat,
 {


### PR DESCRIPTION
The suffix is at best pointless and at worst confusing, therefore I decided to remove it. This is of course a breaking change. 